### PR TITLE
Fix GitHub spelling

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
                         <div class="navbar-start">
                             <a class="navbar-item" href="/qview">qView</a>
                             <a class="navbar-item" href="/discord">Discord</a>
-                            <a class="navbar-item" href="https://github.com/jurplel">Github</a>
+                            <a class="navbar-item" href="https://github.com/jurplel">GitHub</a>
                         </div>
                     </div>
                 </div>
@@ -77,7 +77,7 @@
                     <h5 class="subtitle is-size-5">An image viewer designed to be practical and minimal</h5>
                     <div class="buttons is-centered has-addons">
                         <a class="intvbutton is-medium" href="qview">Website</a>
-                        <a class="intvbutton is-medium" href="https://github.com/jurplel/qView">Github</a>
+                        <a class="intvbutton is-medium" href="https://github.com/jurplel/qView">GitHub</a>
                     </div>
                 </div>
                 <div class="column is-half">
@@ -94,7 +94,7 @@
         <div class="container" style="margin: auto">
             <div class="columns is-centered has-perspective">
                 <div class="column has-text-centered" id="contact1">
-                    <h5 class="is-size-5"><a href="https://github.com/jurplel">jurplel on Github</a></h5>
+                    <h5 class="is-size-5"><a href="https://github.com/jurplel">jurplel on GitHub</a></h5>
                 </div>
                 <div class="column has-text-centered" id="contact2">
                     <h4 class="is-size-4"><a href="discord">Join Interverse on Discord</a></h4>

--- a/qview/assets/js/qview.js
+++ b/qview/assets/js/qview.js
@@ -13,7 +13,7 @@ var navbarHTML = `
             <a class="navbar-item" href="/qview/download">Download</a>
             <a class="navbar-item" href="/qview/changelog">Changelog</a>
             <a class="navbar-item" href="/qview/formats">Supported Formats</a>
-            <a class="navbar-item" href="https://github.com/jurplel/qView">Github</a>
+            <a class="navbar-item" href="https://github.com/jurplel/qView">GitHub</a>
             <a class="navbar-item" href="/discord">Discord</a>
         </div>
         <div class="navbar-end">

--- a/qview/index.html
+++ b/qview/index.html
@@ -128,7 +128,7 @@
                     </div>
                     <div class="column">
                         <h3 class="title">Free and open-source</h3>
-                        <p>qView is completely free and open source software based on Qt5. It can be found on Github under the
+                        <p>qView is completely free and open source software based on Qt5. It can be found on GitHub under the
                             GPLv3 license.</p>
                     </div>
                 </div>

--- a/welcomething/index.html
+++ b/welcomething/index.html
@@ -50,7 +50,7 @@
                         <div class="navbar-start">
                             <a class="navbar-item" href="/qview">qView</a>
                             <a class="navbar-item" href="/discord">Discord</a>
-                            <a class="navbar-item" href="https://github.com/jurplel">Github</a>
+                            <a class="navbar-item" href="https://github.com/jurplel">GitHub</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.